### PR TITLE
Discard master/slave phrasing

### DIFF
--- a/lib/i2c_master.py
+++ b/lib/i2c_master.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim
@@ -21,17 +21,17 @@ init()
 from lib.logger import Logger, Level
 
 # ..............................................................................
-class I2cMaster():
+class I2cMain():
     '''
-        A Raspberry Pi Master for a corresponding Arduino Slave.
+        A Raspberry Pi Main for a corresponding Arduino Subordinate.
 
         Parameters:
-          device_id:  the I²C address over which the master and slave communicate
+          device_id:  the I²C address over which the main and subordinate communicate
           level:      the log level, e.g., Level.INFO
     '''
     def __init__(self, device_id, level):
         super().__init__()
-        self._log = Logger('i²cmaster-0x{:02x}'.format(device_id), level)
+        self._log = Logger('i²cmain-0x{:02x}'.format(device_id), level)
         self._device_id = device_id
         self._log.debug('initialising to communicate over I²C address 0x{:02X}...'.format(device_id))
         try:
@@ -196,7 +196,7 @@ class I2cMaster():
                 self._handle = None
                 self._log.debug('I²C device at handle {} closed.'.format(self._handle))
             except Exception as e:
-                self._log.error('error closing master: {}'.format(e))
+                self._log.error('error closing main: {}'.format(e))
         else:
             self._log.debug('I²C device at handle {} closed.'.format(self._handle))
 
@@ -206,8 +206,8 @@ class I2cMaster():
     # ..........................................................................
     def test_echo(self):
         '''
-            Performs a simple test, sending a series of bytes to the slave, then
-            reading the return values. The Arduino slave's 'isEchoTest' boolean
+            Performs a simple test, sending a series of bytes to the subordinate, then
+            reading the return values. The Arduino subordinate's 'isEchoTest' boolean
             must be set to true. This does not require any hardware configuration
             save that the Raspberry Pi must be connected to the Arduino via I²C
             and that there is no contention on address 0x08.
@@ -270,7 +270,7 @@ class I2cMaster():
         except KeyboardInterrupt:
             self._log.warning('Ctrl-C caught; exiting...')
         except Exception as e:
-            self._log.error('error in master: {}'.format(e))
+            self._log.error('error in main: {}'.format(e))
             traceback.print_exc(file=sys.stdout)
 
 
@@ -363,7 +363,7 @@ class I2cMaster():
         except KeyboardInterrupt:
             self._log.warning('Ctrl-C caught; exiting...')
         except Exception as e:
-            self._log.error('error in master: {}'.format(e))
+            self._log.error('error in main: {}'.format(e))
             traceback.print_exc(file=sys.stdout)
 #       finally:
 #           self.close()

--- a/test_blink.py
+++ b/test_blink.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim
@@ -22,7 +22,7 @@
 #
 
 from lib.logger import Level
-from lib.i2c_master import I2cMaster
+from lib.i2c_main import I2cMain
 
 # ..............................................................................
 def main():
@@ -30,10 +30,10 @@ def main():
     try:
 
         _device_id = 0x08  # must match Arduino's SLAVE_I2C_ADDRESS
-        _master = I2cMaster(_device_id, Level.INFO)
-        if _master is not None: 
+        _main = I2cMain(_device_id, Level.INFO)
+        if _main is not None: 
 
-            _master.test_blink_led(7) # see documentation for hardware configuration
+            _main.test_blink_led(7) # see documentation for hardware configuration
 
         else:
             raise Exception('unable to establish contact with Arduino on address 0x{:02X}'.format(_device_id))
@@ -41,8 +41,8 @@ def main():
     except KeyboardInterrupt:
         self._log.warning('Ctrl-C caught; exiting...')
     finally:
-        if _master:
-            _master.close()
+        if _main:
+            _main.close()
 
 
 if __name__== "__main__":

--- a/test_config.py
+++ b/test_config.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim
@@ -19,7 +19,7 @@
 #
 
 from lib.logger import Level
-from lib.i2c_master import I2cMaster
+from lib.i2c_main import I2cMain
 
 # ..............................................................................
 def main():
@@ -27,13 +27,13 @@ def main():
     try:
 
         _device_id = 0x08  # must match Arduino's SLAVE_I2C_ADDRESS
-        _master = I2cMaster(_device_id, Level.INFO)
+        _main = I2cMain(_device_id, Level.INFO)
 
-        if _master is not None: 
+        if _main is not None: 
 
             # set it to some very large number if you want it to go on for a long time...
             _loop_count = 100
-            _master.test_configuration(_loop_count) # see documentation for hardware configuration
+            _main.test_configuration(_loop_count) # see documentation for hardware configuration
 
         else:
             raise Exception('unable to establish contact with Arduino on address 0x{:02X}'.format(_device_id))
@@ -41,8 +41,8 @@ def main():
     except KeyboardInterrupt:
         self._log.warning('Ctrl-C caught; exiting...')
     finally:
-        if _master:
-            _master.close()
+        if _main:
+            _main.close()
 
 
 if __name__== "__main__":

--- a/test_echo.py
+++ b/test_echo.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 by Murray Altheim. All rights reserved. This file is part
-# of the pimaster2ardslave project and is released under the MIT Licence;
+# of the pimain2ardsubordinate project and is released under the MIT Licence;
 # please see the LICENSE file included as part of this package.
 #
 # author:   Murray Altheim
@@ -13,7 +13,7 @@
 # doesn't require any sensors or additional hardware other than the I²C
 # between the two boards. Communication is over address 0x08, so be sure
 # that is not being used by another device. For the test to function be sure
-# to set the 'isEchoTest' flag on the Arduino's i2cSlave.ino sketch to true,
+# to set the 'isEchoTest' flag on the Arduino's i2cSubordinate.ino sketch to true,
 # otherwise it won't echo the requests but rather respond to them.
 #
 # This requires installation of pigpio, e.g.:
@@ -22,7 +22,7 @@
 #
 
 from lib.logger import Level
-from lib.i2c_master import I2cMaster
+from lib.i2c_main import I2cMain
 
 # ..............................................................................
 def main():
@@ -30,11 +30,11 @@ def main():
     try:
 
         _device_id = 0x08  # must match Arduino's SLAVE_I2C_ADDRESS
-        _master = I2cMaster(_device_id, Level.INFO)
+        _main = I2cMain(_device_id, Level.INFO)
 
-        if _master is not None:
+        if _main is not None:
 
-            _master.test_echo() # requires 'isEchoTest' on Arduino to be set true
+            _main.test_echo() # requires 'isEchoTest' on Arduino to be set true
 
         else:
             raise Exception('unable to establish contact with Arduino on address 0x{:02X}'.format(_device_id))
@@ -42,8 +42,8 @@ def main():
     except KeyboardInterrupt:
         self._log.warning('Ctrl-C caught; exiting...')
     finally:
-        if _master:
-            _master.close()
+        if _main:
+            _main.close()
 
 
 if __name__== "__main__":


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.